### PR TITLE
Update client to match server

### DIFF
--- a/PULL_REQUEST_TEMPLATE
+++ b/PULL_REQUEST_TEMPLATE
@@ -1,0 +1,19 @@
+## JIRA Issue
+[FPW-](https://jira.finn.no/browse/FPW-)
+
+## Status
+**READY/IN DEVELOPMENT/HOLD**
+
+## Description
+<!-- A few sentences describing the overall goals of the pull request's commits. -->
+
+## Todos
+- [ ] Tests
+- [ ] Documentation
+
+## Deploy Notes
+<!-- Notes regarding deployment of the contained body of work. These should note any
+db migrations, etc. -->
+
+## Related PRs
+* None

--- a/README.md
+++ b/README.md
@@ -17,21 +17,20 @@
 
 [![Greenkeeper badge](https://badges.greenkeeper.io/asset-pipe/asset-pipe-client.svg)](https://greenkeeper.io/)
 
-A client for read an [CommonJS module][commonjs] entry point and uploading it as an asset feeds to- and
-triggering builds of executable asset bundles in the [asset-pipe-build-server][asset-pipe-build-server].
+A client for reading an asset file entry point and uploading it as an asset feed to a [asset-pipe-build-server][asset-pipe-build-server]
+and for triggering builds of executable asset bundles in the said server.
 
 Creating asset bundles with [asset-pipe][asset-pipe] is a two step process. The first step is to upload
-an asset feed to the [asset-pipe-build-server][asset-pipe-build-server]. On an upload the asset-feed
+an asset feed to the [asset-pipe-build-server][asset-pipe-build-server]. On upload the asset-feed
 will be persisted and the [asset-pipe-build-server][asset-pipe-build-server] will return the generated
 filename of the uploaded asset-feed.
 
 The second step is then to create a bundle out of one or multiple asset-feeds. This is done by providing
-the unique ID(s) of the asset-feeds one want to use to build an asset bundle to the
+the unique ID(s) of the asset-feeds one wants to use to build an asset bundle to the
 [asset-pipe-build-server][asset-pipe-build-server]. The build server will then create an executable asset
 bundle out of these asset-feeds and persist this. It will respond with the URL to the bundle.
 
-This client helps with remotly triggering these steps in the [asset-pipe-build-server][asset-pipe-build-server].
-
+This client helps with remotely triggering these steps in the [asset-pipe-build-server][asset-pipe-build-server].
 
 
 ## Installation
@@ -39,8 +38,6 @@ This client helps with remotly triggering these steps in the [asset-pipe-build-s
 ```bash
 $ npm install asset-pipe-client
 ```
-
-
 
 ## Example I
 
@@ -64,10 +61,31 @@ client.uploadFeed(['path/to/myFrontendCode.js'])
     });
 ```
 
-
 ## Example II
 
-Build an javascript bundle out of two asset feeds:
+Read a CSS file entry point and upload it as an asset-feed to the
+[asset-pipe-build-server][asset-pipe-build-server]:
+
+```js
+const Client = require('asset-pipe-client');
+
+const client = new Client({
+    buildServerUri: 'http://127.0.0.1:7100',
+});
+
+client.uploadFeed(['/path/to/styles.css'])
+    .then((content) => {
+        // content contains filename of created the asset-feed
+        console.log(content);
+    })
+    .catch((error) => {
+        console.log(error);
+    });
+```
+
+## Example III
+
+Build a javascript bundle out of two asset feeds:
 
 ```js
 const Client = require('asset-pipe-client');
@@ -76,9 +94,9 @@ const client = new Client({
 });
 
 bundle.createRemoteBundle([
-        'f09a737b36b7ca19a224e0d78cc50222d636fd7af6f7913b01521590d0d7fe02.json',
-        'c50ca03a63650502e1b72baf4e493d2eaa0e4aa38aa2951825e101b1d6ddb68b.json'
-    ])
+    'f09a737b36b7ca19a224e0d78cc50222d636fd7af6f7913b01521590d0d7fe02.json',
+    'c50ca03a63650502e1b72baf4e493d2eaa0e4aa38aa2951825e101b1d6ddb68b.json'
+], 'js')
     .then((content) => {
         // content contains URI to the created bundle
         console.log(content);
@@ -88,15 +106,38 @@ bundle.createRemoteBundle([
     });
 ```
 
+## Example IIII
 
+Build a CSS bundle out of two asset feeds:
+
+```js
+const Client = require('asset-pipe-client');
+const client = new Client({
+    buildServerUri: 'http://127.0.0.1:7100',
+});
+
+bundle.createRemoteBundle([
+    'f09a737b36b7ca19a224e0d78cc50222d636fd7af6f7913b01521590d0d7fe02.json',
+    'c50ca03a63650502e1b72baf4e493d2eaa0e4aa38aa2951825e101b1d6ddb68b.json'
+], 'css')
+    .then((content) => {
+        // content contains URI to the created bundle
+        console.log(content);
+    })
+    .catch((error) => {
+        console.log(error);
+    });
+```
 
 ## API
 
-Under the hood, the [asset-pipe][asset-pipe] project build on [browserify][Browserify]. Multiple methods
-in this module are therefor underlaying Browserify methods where all features found in Browserify can
+Under the hood, when working with javascript, the [asset-pipe][asset-pipe] project builds on [browserify][Browserify]. 
+Multiple methods in this module are therefor underlaying Browserify methods where all features found in Browserify can
 be used. Such methods will in this documentation point to the related documentation in Browserify.
 
-This module have the following API:
+When working with CSS the underlying POST CSS is used but the implementation is not exposed so there are no additional supported methods.
+
+This module has the following API:
 
 ### constructor(options)
 
@@ -107,31 +148,32 @@ Supported arguments are:
 ### transform()
 
 Same as the [Browserify transform][browserify-transform] method.
+*NOTE:* Only applicable when uploading javascript feeds.
 
 ### plugin()
 
 Same as the [Browserify plugin][browserify-plugin] method.
+*NOTE:* Only applicable when uploading javascript feeds.
 
 ### uploadFeed(files)
 
-Read the [CommonJS module][commonjs] entry point and uploads it as an asset feeds to the [asset-pipe-build-server][asset-pipe-build-server].
+Read the [CommonJS module][commonjs] or CSS file entry point and uploads it as an asset feed to the [asset-pipe-build-server][asset-pipe-build-server].
 
- * `files` - Array - List of CommonJS module entry points - Same as `files` in the [Browserify constructor][browserify-opts]
+ * `files` - Array - Either list of CommonJS module entry points - Same as `files` in the [Browserify constructor][browserify-opts] OR list of paths to CSS files
 
 Returns a promise.
 
-### createRemoteBundle(feeds)
+### createRemoteBundle(feeds, type)
 
 Creates an asset bundle on the [asset-pipe-build-server][asset-pipe-build-server].
 
  * `feeds` - Array - List of asset-feed filenames.
-
-
+ * `type` - string - Either 'js' or 'css'
 
 ## Transpilers
 
 Since [asset-pipe][asset-pipe] is built on [browserify][Browserify] under the hood, its fully possible
-to take advantage of the different transpiers available for [browserify][Browserify].
+to take advantage of the different transpiers available for [browserify][Browserify] when working with javascript.
 
 As an example, here is how Babel is applied:
 

--- a/lib/main.js
+++ b/lib/main.js
@@ -19,6 +19,8 @@ const endpoints = Object.freeze({
     BUNDLE: 'bundle',
 });
 
+const assetTypes = Object.freeze(['js', 'css']);
+
 function post(options) {
     const opts = {
         url: options.url,
@@ -87,7 +89,10 @@ module.exports = class Client {
         });
 
         return post({
-            url: url.resolve(this.options.buildServerUri, endpoints.UPLOAD),
+            url: url.resolve(
+                this.options.buildServerUri,
+                `${endpoints.UPLOAD}/js`
+            ),
             body: writer.bundle().pipe(JSONStream.stringify()),
         });
     }
@@ -95,7 +100,10 @@ module.exports = class Client {
     uploadCssFeed(files) {
         const writer = new CssWriter(files);
         return post({
-            url: url.resolve(this.options.buildServerUri, endpoints.UPLOAD),
+            url: url.resolve(
+                this.options.buildServerUri,
+                `${endpoints.UPLOAD}/css`
+            ),
             body: writer.pipe(JSONStream.stringify()),
         });
     }
@@ -151,9 +159,18 @@ module.exports = class Client {
      * Make a bundle out of asset feeds on the asset server
      */
 
-    async createRemoteBundle(sources) {
+    async createRemoteBundle(sources, type) {
+        assert(
+            assetTypes.includes(type),
+            `Expected argument 'type' to be one of ${assetTypes.join(
+                '|'
+            )}. Instead got '${type}'`
+        );
         const { response, body } = await post({
-            url: url.resolve(this.options.buildServerUri, endpoints.BUNDLE),
+            url: url.resolve(
+                this.options.buildServerUri,
+                `${endpoints.BUNDLE}/${type}`
+            ),
             body: JSON.stringify(sources),
         });
 

--- a/lib/main.js
+++ b/lib/main.js
@@ -19,7 +19,7 @@ const endpoints = Object.freeze({
     BUNDLE: 'bundle',
 });
 
-const assetTypes = Object.freeze(['js', 'css']);
+const assetTypes = ['js', 'css'];
 
 function post(options) {
     const opts = {

--- a/lib/main.js
+++ b/lib/main.js
@@ -161,6 +161,18 @@ module.exports = class Client {
 
     async createRemoteBundle(sources, type) {
         assert(
+            Array.isArray(sources),
+            `Expected argument 'sources' to be an array. Instead got ${typeof sources}`
+        );
+        assert(
+            sources.every(source => typeof source === 'string'),
+            `Expected all entries in array 'sources' to be strings. Instead got ${sources}`
+        );
+        assert(
+            sources.every(source => source.includes('.json')),
+            `Expected ALL items in array 'sources' to end with .json. Instead got ${sources}`
+        );
+        assert(
             assetTypes.includes(type),
             `Expected argument 'type' to be one of ${assetTypes.join(
                 '|'

--- a/package.json
+++ b/package.json
@@ -22,7 +22,8 @@
     "Sveinung Røsaker <sveinung.rosaker@gmail.com>",
     "Trygve Lie (http://www.trygve-lie.com/)",
     "Sveinung Røsaker (https://github.com/sveisvei)",
-    "Greenkeeper (http://greenkeeper.io/)"
+    "Greenkeeper (http://greenkeeper.io/)",
+    "Richard Walker (https://github.com/digitalsadhu)"
   ],
   "bugs": {
     "url": "https://github.com/asset-pipe/asset-pipe-client/issues"

--- a/test/integration/main.test.js
+++ b/test/integration/main.test.js
@@ -225,7 +225,7 @@ test('createRemoteBundle(sources) - 200', async () => {
             cb: (req, res) => res.send(req.body),
         },
     ]);
-    const fakeSources = ['a12das3d', '12da321fd'];
+    const fakeSources = ['a12das3d.json', '12da321fd.json'];
 
     const client = new Client({ buildServerUri: `http://127.0.0.1:${port}` });
     const result = client.createRemoteBundle(fakeSources, 'js');
@@ -243,7 +243,7 @@ test('createRemoteBundle(sources) - 202', async () => {
             cb: (req, res) => res.status(202).send({ message: 'success 202' }),
         },
     ]);
-    const fakeSources = ['a12das3d', '12da321fd'];
+    const fakeSources = ['a12das3d.json', '12da321fd.json'];
 
     const client = new Client({ buildServerUri: `http://127.0.0.1:${port}` });
     const result = client.createRemoteBundle(fakeSources, 'js');
@@ -261,7 +261,7 @@ test('createRemoteBundle(sources) - 400', async () => {
             cb: (req, res) => res.status(400).send({ message: 'Bad request' }),
         },
     ]);
-    const fakeSources = ['a12das3d', '12da321fd'];
+    const fakeSources = ['a12das3d.json', '12da321fd.json'];
 
     const client = new Client({ buildServerUri: `http://127.0.0.1:${port}` });
     const result = client.createRemoteBundle(fakeSources, 'js');
@@ -280,7 +280,7 @@ test('createRemoteBundle(sources) - other status codes', async () => {
                 res.status(420).send({ message: 'Its that time again' }),
         },
     ]);
-    const fakeSources = ['a12das3d', '12da321fd'];
+    const fakeSources = ['a12das3d.json', '12da321fd.json'];
 
     const client = new Client({ buildServerUri: `http://127.0.0.1:${port}` });
     const result = client.createRemoteBundle(fakeSources, 'js');

--- a/test/integration/main.test.js
+++ b/test/integration/main.test.js
@@ -72,7 +72,7 @@ test('uploadFeed(files, options) - js', async () => {
     const { server, port } = await createTestServer([
         {
             verb: 'post',
-            path: '/feed',
+            path: '/feed/js',
             cb(req, res) {
                 res.send({ message: 'Success!' });
             },
@@ -93,7 +93,7 @@ test('uploadFeed(files, options) - js - uses transforms', async () => {
     const { server, port } = await createTestServer([
         {
             verb: 'post',
-            path: '/feed',
+            path: '/feed/js',
             cb: (req, res) => res.send('Success!'),
         },
     ]);
@@ -119,7 +119,7 @@ test('uploadFeed(files, options) - js - uses plugins', async () => {
     const { server, port } = await createTestServer([
         {
             verb: 'post',
-            path: '/feed',
+            path: '/feed/js',
             cb: (req, res) => res.send({ message: 'Success!' }),
         },
     ]);
@@ -142,7 +142,7 @@ test('uploadFeed(files) - 200', async () => {
     const { server, port } = await createTestServer([
         {
             verb: 'post',
-            path: '/feed',
+            path: '/feed/js',
             cb: (req, res) => res.status(200).send({ message: 'Bad request!' }),
         },
     ]);
@@ -161,7 +161,7 @@ test('uploadFeed(files) - 400', async () => {
     const { server, port } = await createTestServer([
         {
             verb: 'post',
-            path: '/feed',
+            path: '/feed/js',
             cb: (req, res) => res.status(400).send({ message: 'Bad request!' }),
         },
     ]);
@@ -180,7 +180,7 @@ test('uploadFeed(files) - other status codes', async () => {
     const { server, port } = await createTestServer([
         {
             verb: 'post',
-            path: '/feed',
+            path: '/feed/js',
             cb: (req, res) => res.status(300).send({ message: 'Bad request!' }),
         },
     ]);
@@ -203,7 +203,7 @@ test('uploadFeed(files) - css', async () => {
     const { server, port } = await createTestServer([
         {
             verb: 'post',
-            path: '/feed',
+            path: '/feed/css',
             cb: (req, res) => res.status(200).send(req.body),
         },
     ]);
@@ -221,14 +221,14 @@ test('createRemoteBundle(sources) - 200', async () => {
     const { server, port } = await createTestServer([
         {
             verb: 'post',
-            path: '/bundle',
+            path: '/bundle/js',
             cb: (req, res) => res.send(req.body),
         },
     ]);
     const fakeSources = ['a12das3d', '12da321fd'];
 
     const client = new Client({ buildServerUri: `http://127.0.0.1:${port}` });
-    const result = client.createRemoteBundle(fakeSources);
+    const result = client.createRemoteBundle(fakeSources, 'js');
 
     await expect(result).resolves.toEqual(fakeSources);
     await closeServer(server);
@@ -239,14 +239,14 @@ test('createRemoteBundle(sources) - 202', async () => {
     const { server, port } = await createTestServer([
         {
             verb: 'post',
-            path: '/bundle',
+            path: '/bundle/js',
             cb: (req, res) => res.status(202).send({ message: 'success 202' }),
         },
     ]);
     const fakeSources = ['a12das3d', '12da321fd'];
 
     const client = new Client({ buildServerUri: `http://127.0.0.1:${port}` });
-    const result = client.createRemoteBundle(fakeSources);
+    const result = client.createRemoteBundle(fakeSources, 'js');
 
     await expect(result).resolves.toEqual({ message: 'success 202' });
     await closeServer(server);
@@ -257,14 +257,14 @@ test('createRemoteBundle(sources) - 400', async () => {
     const { server, port } = await createTestServer([
         {
             verb: 'post',
-            path: '/bundle',
+            path: '/bundle/js',
             cb: (req, res) => res.status(400).send({ message: 'Bad request' }),
         },
     ]);
     const fakeSources = ['a12das3d', '12da321fd'];
 
     const client = new Client({ buildServerUri: `http://127.0.0.1:${port}` });
-    const result = client.createRemoteBundle(fakeSources);
+    const result = client.createRemoteBundle(fakeSources, 'js');
 
     await expect(result).rejects.toEqual(new Error('Bad request'));
     await closeServer(server);
@@ -275,7 +275,7 @@ test('createRemoteBundle(sources) - other status codes', async () => {
     const { server, port } = await createTestServer([
         {
             verb: 'post',
-            path: '/bundle',
+            path: '/bundle/js',
             cb: (req, res) =>
                 res.status(420).send({ message: 'Its that time again' }),
         },
@@ -283,7 +283,7 @@ test('createRemoteBundle(sources) - other status codes', async () => {
     const fakeSources = ['a12das3d', '12da321fd'];
 
     const client = new Client({ buildServerUri: `http://127.0.0.1:${port}` });
-    const result = client.createRemoteBundle(fakeSources);
+    const result = client.createRemoteBundle(fakeSources, 'js');
 
     await expect(result).rejects.toEqual(
         new Error(

--- a/test/integration/main.test.js
+++ b/test/integration/main.test.js
@@ -234,6 +234,24 @@ test('createRemoteBundle(sources) - 200', async () => {
     await closeServer(server);
 });
 
+test('createRemoteBundle(sources) - css', async () => {
+    expect.assertions(1);
+    const { server, port } = await createTestServer([
+        {
+            verb: 'post',
+            path: '/bundle/css',
+            cb: (req, res) => res.send(req.body),
+        },
+    ]);
+    const fakeSources = ['a12das3d.json', '12da321fd.json'];
+
+    const client = new Client({ buildServerUri: `http://127.0.0.1:${port}` });
+    const result = client.createRemoteBundle(fakeSources, 'css');
+
+    await expect(result).resolves.toEqual(fakeSources);
+    await closeServer(server);
+});
+
 test('createRemoteBundle(sources) - 202', async () => {
     expect.assertions(1);
     const { server, port } = await createTestServer([

--- a/test/unit/__snapshots__/main.test.js.snap
+++ b/test/unit/__snapshots__/main.test.js.snap
@@ -1,5 +1,15 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`createRemoteBundle() - missing source argument 1`] = `[AssertionError [ERR_ASSERTION]: Expected argument 'sources' to be an array. Instead got undefined]`;
+
+exports[`createRemoteBundle(sources) - invalid source argument 1`] = `[AssertionError [ERR_ASSERTION]: Expected argument 'sources' to be an array. Instead got string]`;
+
+exports[`createRemoteBundle(sources) - invalid type 1`] = `[AssertionError [ERR_ASSERTION]: Expected argument 'type' to be one of js|css. Instead got 'fake']`;
+
+exports[`createRemoteBundle(sources) - missing type 1`] = `[AssertionError [ERR_ASSERTION]: Expected argument 'type' to be one of js|css. Instead got 'undefined']`;
+
+exports[`createRemoteBundle(sources) - source argument missing .json ext. 1`] = `[AssertionError [ERR_ASSERTION]: Expected ALL items in array 'sources' to end with .json. Instead got a1c12a45ca1ac1ca1cc1ac1ca1]`;
+
 exports[`uploadFeed() - files array must contain .css or .js filenames 1`] = `
 [AssertionError [ERR_ASSERTION]: Expected ALL items in array 'files' to end with .js 
                 or ALL items in array 'files' to end with .css, got one,two]

--- a/test/unit/main.test.js
+++ b/test/unit/main.test.js
@@ -150,7 +150,7 @@ test('uploadFeed(files) - request error', async () => {
 });
 
 test('createRemoteBundle(sources) - request error', async () => {
-    expect.hasAssertions();
+    expect.assertions(1);
     jest.resetModules();
     jest.doMock('request', () => createRequestMock(new Error('Fake error!')));
     jest.doMock('asset-pipe-js-writer', () => createJsWriterMock());
@@ -161,4 +161,56 @@ test('createRemoteBundle(sources) - request error', async () => {
     const result = client.createRemoteBundle(fakeSources, 'js');
 
     await expect(result).rejects.toEqual(new Error('Fake error!'));
+});
+
+test('createRemoteBundle() - missing source argument', async () => {
+    expect.assertions(1);
+    const client = new Client();
+    try {
+        await client.createRemoteBundle();
+    } catch (err) {
+        expect(err).toMatchSnapshot();
+    }
+});
+
+test('createRemoteBundle(sources) - invalid source argument', async () => {
+    expect.assertions(1);
+    const client = new Client();
+    try {
+        await client.createRemoteBundle('asd');
+    } catch (err) {
+        expect(err).toMatchSnapshot();
+    }
+});
+
+test('createRemoteBundle(sources) - source argument missing .json ext.', async () => {
+    expect.assertions(1);
+    const client = new Client();
+    try {
+        await client.createRemoteBundle(['a1c12a45ca1ac1ca1cc1ac1ca1']);
+    } catch (err) {
+        expect(err).toMatchSnapshot();
+    }
+});
+
+test('createRemoteBundle(sources) - missing type', async () => {
+    expect.assertions(1);
+    const client = new Client();
+    const fakeSources = ['a12das3d.json', '12da321fd.json'];
+    try {
+        await client.createRemoteBundle(fakeSources);
+    } catch (err) {
+        expect(err).toMatchSnapshot();
+    }
+});
+
+test('createRemoteBundle(sources) - invalid type', async () => {
+    expect.assertions(1);
+    const client = new Client();
+    const fakeSources = ['a12das3d.json', '12da321fd.json'];
+    try {
+        await client.createRemoteBundle(fakeSources, 'fake');
+    } catch (err) {
+        expect(err).toMatchSnapshot();
+    }
 });

--- a/test/unit/main.test.js
+++ b/test/unit/main.test.js
@@ -155,7 +155,7 @@ test('createRemoteBundle(sources) - request error', async () => {
     jest.doMock('request', () => createRequestMock(new Error('Fake error!')));
     jest.doMock('asset-pipe-js-writer', () => createJsWriterMock());
     Client = require('../../');
-    const fakeSources = ['a12das3d', '12da321fd'];
+    const fakeSources = ['a12das3d.json', '12da321fd.json'];
     const client = new Client();
 
     const result = client.createRemoteBundle(fakeSources, 'js');

--- a/test/unit/main.test.js
+++ b/test/unit/main.test.js
@@ -158,7 +158,7 @@ test('createRemoteBundle(sources) - request error', async () => {
     const fakeSources = ['a12das3d', '12da321fd'];
     const client = new Client();
 
-    const result = client.createRemoteBundle(fakeSources);
+    const result = client.createRemoteBundle(fakeSources, 'js');
 
     await expect(result).rejects.toEqual(new Error('Fake error!'));
 });


### PR DESCRIPTION
## JIRA Issue
[LBC-34](https://jira.finn.no/browse/LBC-34)

## Status
**READY**

## Description
Aligns client with changes to the server API. Specifically that there are now 2 endpoints for each task. `/feeds/js` + `/feeds/css` AND `/bundle/js` + `/bundle/css`.

This PR includes 1 breaking change in that `createRemoteBundle` now requires a second argument to specify which type of asset the supplied source hashes are.

Example:
```js
client.createRemoteBundle([
  'aae1ace21ac2ea1c2ea1c2e1ac2e1ac2e121.json',
  'bae1ace21ac2ea1c2ea1c2e1ac2e1ac2e12a.json',
  'cae1ace21ac2ea1c2ea1c2e1ac2e1ac2e12b.json',
], 'js')
```

## Todos
- [x] Tests
- [x] Documentation

## Related PRs
* https://github.com/asset-pipe/asset-pipe-build-server/pull/85