### PR TITLE
Add serverId as header 

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,7 +1,10 @@
 {
   "root": true,
   "parserOptions": {
-    "ecmaVersion": 2017
+    "ecmaVersion": 2017,
+    "ecmaFeatures": {
+      "experimentalObjectRestSpread": true
+    }
   },
   "extends": [
     "finn",

--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ Read an [CommonJS module][commonjs] entry point and upload it as an asset-feed t
 const Client = require('asset-pipe-client');
 
 const client = new Client({
+    serverId: 'my-app-1',
     buildServerUri: 'http://127.0.0.1:7100',
 });
 
@@ -90,6 +91,7 @@ Build a javascript bundle out of two asset feeds:
 ```js
 const Client = require('asset-pipe-client');
 const client = new Client({
+    serverId: 'my-app-2',
     buildServerUri: 'http://127.0.0.1:7100',
 });
 
@@ -131,7 +133,7 @@ bundle.createRemoteBundle([
 
 ## API
 
-Under the hood, when working with javascript, the [asset-pipe][asset-pipe] project builds on [browserify][Browserify]. 
+Under the hood, when working with javascript, the [asset-pipe][asset-pipe] project builds on [browserify][Browserify].
 Multiple methods in this module are therefor underlaying Browserify methods where all features found in Browserify can
 be used. Such methods will in this documentation point to the related documentation in Browserify.
 
@@ -143,7 +145,8 @@ This module has the following API:
 
 Supported arguments are:
 
- * `options.buildServerUri` - URI to the [asset-pipe-build-server][asset-pipe-build-server]
+ * `options.buildServerUri` - Required URI to the [asset-pipe-build-server][asset-pipe-build-server]
+ * `options.serverId` - An optional unique name to identify the deployed server (required for runtime optimistic bundling)
 
 ### transform()
 

--- a/lib/main.js
+++ b/lib/main.js
@@ -31,6 +31,10 @@ function post(options) {
         },
     };
 
+    if (options.serverId) {
+        opts.headers['origin-server-id'] = options.serverId;
+    }
+
     if (!isStream(options.body)) {
         opts.body = options.body;
     }
@@ -51,13 +55,13 @@ function post(options) {
 }
 
 module.exports = class Client {
-    constructor(options = {}) {
-        this.options = Object.assign(
-            {
-                buildServerUri: 'http://127.0.0.1:7100',
-            },
-            options
+    constructor({ serverId, buildServerUri } = {}) {
+        assert(
+            buildServerUri,
+            `Expected "buildServerUri" to be a uri, got ${buildServerUri}`
         );
+        this.buildServerUri = buildServerUri;
+        this.serverId = serverId;
 
         this.transforms = [];
         this.plugins = [];
@@ -89,22 +93,18 @@ module.exports = class Client {
         });
 
         return post({
-            url: url.resolve(
-                this.options.buildServerUri,
-                `${endpoints.UPLOAD}/js`
-            ),
+            url: url.resolve(this.buildServerUri, `${endpoints.UPLOAD}/js`),
             body: writer.bundle().pipe(JSONStream.stringify()),
+            serverId: this.serverId,
         });
     }
 
     uploadCssFeed(files) {
         const writer = new CssWriter(files);
         return post({
-            url: url.resolve(
-                this.options.buildServerUri,
-                `${endpoints.UPLOAD}/css`
-            ),
+            url: url.resolve(this.buildServerUri, `${endpoints.UPLOAD}/css`),
             body: writer.pipe(JSONStream.stringify()),
+            serverId: this.serverId,
         });
     }
 
@@ -128,8 +128,9 @@ module.exports = class Client {
         assert(
             files.every(file => file.includes('.js')) ||
                 files.every(file => file.includes('.css')),
-            `Expected ALL items in array 'files' to end with .js 
-                or ALL items in array 'files' to end with .css, got ${files}`
+            `Expected ALL items in array 'files' to end with .js or ALL items in array 'files' to end with .css, got ${files.join(
+                ', '
+            )}`
         );
 
         let upload;
@@ -180,10 +181,11 @@ module.exports = class Client {
         );
         const { response, body } = await post({
             url: url.resolve(
-                this.options.buildServerUri,
+                this.buildServerUri,
                 `${endpoints.BUNDLE}/${type}`
             ),
             body: JSON.stringify(sources),
+            serverId: this.serverId,
         });
 
         if ([200, 202].includes(response.statusCode)) {

--- a/package.json
+++ b/package.json
@@ -63,6 +63,9 @@
     "readme": "projectz compile",
     "semantic-release": "semantic-release pre && npm publish && semantic-release post"
   },
+  "engines": {
+    "node": ">=8.9"
+  },
   "jest": {
     "clearMocks": true,
     "coverageThreshold": {

--- a/test/unit/__snapshots__/main.test.js.snap
+++ b/test/unit/__snapshots__/main.test.js.snap
@@ -10,12 +10,11 @@ exports[`createRemoteBundle(sources) - missing type 1`] = `[AssertionError [ERR_
 
 exports[`createRemoteBundle(sources) - source argument missing .json ext. 1`] = `[AssertionError [ERR_ASSERTION]: Expected ALL items in array 'sources' to end with .json. Instead got a1c12a45ca1ac1ca1cc1ac1ca1]`;
 
-exports[`uploadFeed() - files array must contain .css or .js filenames 1`] = `
-[AssertionError [ERR_ASSERTION]: Expected ALL items in array 'files' to end with .js 
-                or ALL items in array 'files' to end with .css, got one,two]
-`;
+exports[`uploadFeed() - files array must contain .css or .js filenames 1`] = `[AssertionError [ERR_ASSERTION]: Expected ALL items in array 'files' to end with .js or ALL items in array 'files' to end with .css, got one, two]`;
 
 exports[`uploadFeed() - files array must only contain strings 1`] = `[AssertionError [ERR_ASSERTION]: Expected each item in array 'files' to be a string, got 1,true]`;
+
+exports[`uploadFeed() - files array must only contain strings 2`] = `[AssertionError [ERR_ASSERTION]: Expected each item in array 'files' to be a string, got 1,true]`;
 
 exports[`uploadFeed() - files must be an array 1`] = `[AssertionError [ERR_ASSERTION]: Expected 'files' to be an array, instead got undefined]`;
 


### PR DESCRIPTION
## JIRA Issue
[COREWEB-40](https://jira.finn.no/browse/COREWEB-40)

## Status
**READY**

## Description
ServerId is going to be used to identify an resource and its usages in the asset-pipe-build-server to allow us to "guess" what a new bundle might look like before its requested. This PR is to send this information to the build-server.

Some compounded changes:
* flattened internal option array
* removed buildServerUri default value
* added serverId as option, and serverId gets appended to request header

## Todos
- [x] Tests
- [x] Documentation

## Deploy Notes
<!-- Notes regarding deployment of the contained body of work. These should note any
db migrations, etc. -->

## Related PRs
* None