### PR TITLE
fix: remove 5000ms timeout

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -24,7 +24,6 @@ const assetTypes = ['js', 'css'];
 function post(options) {
     const opts = {
         url: options.url,
-        timeout: 5000,
         headers: {
             'content-type': 'application/json',
             accept: 'application/json',


### PR DESCRIPTION
## JIRA Issue
N/A

## Status
**READY**

## Description
We have issues both locally and in deployed environments where this timeout is too low. This makes the app unable to be deployed. Instead of setting some arbitrary higher timeout, we should remove it until we are able to set a reasonable timeout.

When we add minification to the bundling the time will go up even more.

## Todos
- [ ] Tests
- [ ] Documentation

## Deploy Notes
<!-- Notes regarding deployment of the contained body of work. These should note any
db migrations, etc. -->

## Related PRs
* None