### PR TITLE
fix: remove unnecessary parameters to writer

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -81,7 +81,7 @@ module.exports = class Client {
     }
 
     uploadJsFeed(files, options) {
-        const writer = new JsWriter(files, options, false, true);
+        const writer = new JsWriter(files, options);
 
         this.transforms.forEach(entry => {
             writer.transform(entry.transform, entry.options);


### PR DESCRIPTION
## JIRA Issue
[COREWEB-196](https://jira.finn.no/browse/COREWEB-196)

## Status
**READY**

## Description
This changes nothing but is more correct. Changes to js-writer made the minify parameter obsolete and since bundle defaults to false there is no need to specify.