### PR TITLE
feat: add support for minify and sourceMaps opts

### DIFF
--- a/README.md
+++ b/README.md
@@ -239,6 +239,8 @@ Supported arguments are:
   [asset-pipe-build-server][asset-pipe-build-server]
 * `options.serverId` - An optional unique name to identify the deployed server
   (required for runtime optimistic bundling)
+* `options.minify` - Use minification (optimistic bundling only) `true|false` Not providing this option will result in server default being used.
+* `options.sourceMaps` - (experimental) Use sourceMaps (optimistic bundling only) `true|false` Not providing this option will result in server default being used.
 
 ### transform()
 
@@ -269,7 +271,7 @@ Creates an asset bundle on the
 * `feeds` - Array - List of asset-feed filenames.
 * `type` - string - Either 'js' or 'css'
 
-### publishAssets(tag, entrypoints)
+### publishAssets(tag, entrypoints, options)
 
 Publishes assets to the asset server for use in optimisitic bundling. Bundles
 will be created according to bundle instructions published using the
@@ -279,6 +281,7 @@ will be created according to bundle instructions published using the
   unique.
 * `entrypoints` - `Array` - Array of asset entrypoint filenames to be published
   to the asset server.
+* `options` - `object` - Bundling options. `{minify: true|false, sourceMaps: true|false}` Setting these options here will override the same options provided to the constructor
 
 `return` - `object` - An object with keys `id` (refering to the unique asset
 hash) and `uri` (referring to the location of the published asset on the
@@ -298,7 +301,15 @@ CSS
 const { uri, id } = await client.publishAssets('podlet1', ['/path/to/file.css']);
 ```
 
-### publishInstructions(tag, type, data)
+With minification
+
+```js
+const { uri, id } = await client.publishAssets('podlet1', ['/path/to/file.js'], {
+    minify: true,
+});
+```
+
+### publishInstructions(tag, type, data, options)
 
 Publishes bundling instructions to the asset server for use in optimisitic
 bundling. Bundles are generated as specified by the `data` array. Anytime new
@@ -311,6 +322,7 @@ instructions are published (via `publishInstructions`) or assets are published
 * `data` - `array` - Array of tags to bundle together. Each tag must refer to
   the tag property given when publishing assets using the `publishAssets`
   method.
+* `options` - `object` - Bundling options. `{minify: true|false, sourceMaps: true|false}` Setting these options here will override the same options provided to the constructor
 
 `return` - 204 No Content is returned when publishing has successfully completed.
 
@@ -326,6 +338,14 @@ CSS
 
 ```js
 await client.publishInstructions('layout', 'css', ['podlet1', 'podlet2']);
+```
+
+With minification
+
+```js
+await client.publishInstructions('layout', 'js', ['podlet1', 'podlet2'], {
+    minify: true,
+});
 ```
 
 ## Transpilers

--- a/lib/main.js
+++ b/lib/main.js
@@ -11,6 +11,7 @@ const isStream = require('is-stream');
 const Joi = require('joi');
 const Boom = require('boom');
 const schemas = require('./schemas');
+const { buildURL } = require('../lib/utils');
 
 function getStream(stream) {
     const data = [];
@@ -68,7 +69,7 @@ function post(options) {
 }
 
 module.exports = class Client {
-    constructor({ serverId, buildServerUri } = {}) {
+    constructor({ serverId, buildServerUri, minify, sourceMaps } = {}) {
         assert(
             buildServerUri,
             `Expected "buildServerUri" to be a uri, got ${buildServerUri}`
@@ -78,6 +79,8 @@ module.exports = class Client {
 
         this.transforms = [];
         this.plugins = [];
+        this.minify = minify;
+        this.sourceMaps = sourceMaps;
     }
 
     transform(transform, options) {
@@ -265,12 +268,18 @@ module.exports = class Client {
             `Invalid 'options' argument given when attempting to publish assets.`
         );
 
+        const opts = {
+            minify: this.minify,
+            sourceMaps: this.sourceMaps,
+            ...options,
+        };
+
         const type = this.determineType(entrypoints);
         const writer = this.writer(type, entrypoints, options);
         const { response: { statusCode }, body } = await post({
-            url: url.resolve(
-                this.buildServerUri,
-                `${endpoints.PUBLISH_ASSETS}`
+            url: buildURL(
+                url.resolve(this.buildServerUri, `${endpoints.PUBLISH_ASSETS}`),
+                { minify: opts.minify, sourceMaps: opts.sourceMaps }
             ),
             body: JSON.stringify({
                 tag,
@@ -298,7 +307,7 @@ module.exports = class Client {
         );
     }
 
-    async publishInstructions(tag, type, data) {
+    async publishInstructions(tag, type, data, options = {}) {
         Joi.assert(
             tag,
             schemas.tag,
@@ -315,10 +324,19 @@ module.exports = class Client {
             `Invalid 'data' argument given when attempting to publish instructions.`
         );
 
+        const opts = {
+            minify: this.minify,
+            sourceMaps: this.sourceMaps,
+            ...options,
+        };
+
         const { response: { statusCode }, body } = await post({
-            url: url.resolve(
-                this.buildServerUri,
-                `${endpoints.PUBLISH_INSTRUCTIONS}`
+            url: buildURL(
+                url.resolve(
+                    this.buildServerUri,
+                    `${endpoints.PUBLISH_INSTRUCTIONS}`
+                ),
+                { minify: opts.minify, sourceMaps: opts.sourceMaps }
             ),
             body: JSON.stringify({ tag, type, data }),
             serverId: this.serverId,

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1,0 +1,19 @@
+'use strict';
+
+const { URL } = require('url');
+
+function buildURL(baseUrl, params = {}) {
+    const url = new URL(baseUrl);
+
+    for (const [name, value] of Object.entries(params)) {
+        if (value) {
+            let val = value;
+            if (value === Object(value)) val = JSON.stringify(value);
+            url.searchParams.set(name, val);
+        }
+    }
+
+    return url.href;
+}
+
+module.exports = { buildURL };

--- a/test/integration/__snapshots__/main.test.js.snap
+++ b/test/integration/__snapshots__/main.test.js.snap
@@ -15,6 +15,30 @@ Object {
 }
 `;
 
+exports[`publishAssets(tag, files, options) - js - minify options 1`] = `
+Object {
+  "minify": "true",
+  "sourceMaps": "true",
+}
+`;
+
+exports[`publishAssets(tag, files, options) - js - query params 1`] = `
+Array [
+  Object {
+    "minify": "true",
+  },
+  Object {},
+  Object {
+    "sourceMaps": "true",
+  },
+  Object {},
+  Object {},
+  Object {},
+]
+`;
+
+exports[`publishAssets(tag, files, options) - js - query params overrides options 1`] = `Object {}`;
+
 exports[`publishAssets(tag, files, options) - js 1`] = `
 Object {
   "data": Array [
@@ -40,6 +64,30 @@ Object {
   "type": "css",
 }
 `;
+
+exports[`publishInstructions(tag, type, data) - js - options 1`] = `
+Object {
+  "minify": "true",
+  "sourceMaps": "true",
+}
+`;
+
+exports[`publishInstructions(tag, type, data) - js - query params 1`] = `
+Array [
+  Object {
+    "minify": "true",
+  },
+  Object {},
+  Object {
+    "sourceMaps": "true",
+  },
+  Object {},
+  Object {},
+  Object {},
+]
+`;
+
+exports[`publishInstructions(tag, type, data) - js - query params overrides options 1`] = `Object {}`;
 
 exports[`publishInstructions(tag, type, data) - js 1`] = `
 Object {

--- a/test/integration/main.test.js
+++ b/test/integration/main.test.js
@@ -438,6 +438,79 @@ test('publishAssets(tag, files, options) - js', async () => {
     await closeServer(server);
 });
 
+test('publishAssets(tag, files, options) - js - minify options', async () => {
+    expect.assertions(1);
+    const { server, port } = await createTestServer([
+        {
+            verb: 'post',
+            path: '/publish-assets',
+            cb(req, res) {
+                res.send(req.query);
+            },
+        },
+    ]);
+    const client = new Client({
+        buildServerUri: `http://127.0.0.1:${port}`,
+        minify: true,
+        sourceMaps: true,
+    });
+
+    const result = await client.publishAssets('a', ['b.js']);
+    expect(result).toMatchSnapshot();
+    await closeServer(server);
+});
+
+test('publishAssets(tag, files, options) - js - query params', async () => {
+    expect.assertions(1);
+    const { server, port } = await createTestServer([
+        {
+            verb: 'post',
+            path: '/publish-assets',
+            cb(req, res) {
+                res.send(req.query);
+            },
+        },
+    ]);
+    const client = new Client({ buildServerUri: `http://127.0.0.1:${port}` });
+
+    const result = await Promise.all([
+        await client.publishAssets('a', ['b.js'], { minify: true }),
+        await client.publishAssets('a', ['b.js'], { minify: false }),
+        await client.publishAssets('a', ['b.js'], { sourceMaps: true }),
+        await client.publishAssets('a', ['b.js'], { sourceMaps: false }),
+        await client.publishAssets('a', ['b.js'], { minify: null }),
+        await client.publishAssets('a', ['b.js'], { sourceMaps: null }),
+    ]);
+
+    expect(result).toMatchSnapshot();
+    await closeServer(server);
+});
+
+test('publishAssets(tag, files, options) - js - query params overrides options', async () => {
+    expect.assertions(1);
+    const { server, port } = await createTestServer([
+        {
+            verb: 'post',
+            path: '/publish-assets',
+            cb(req, res) {
+                res.send(req.query);
+            },
+        },
+    ]);
+    const client = new Client({
+        buildServerUri: `http://127.0.0.1:${port}`,
+        minify: true,
+        sourceMaps: true,
+    });
+
+    const result = await client.publishAssets('a', ['b.js'], {
+        minify: false,
+        sourceMaps: false,
+    });
+    expect(result).toMatchSnapshot();
+    await closeServer(server);
+});
+
 test('publishAssets(tag, files, options) - uses plugins', async () => {
     expect.assertions(1);
     const { server, port } = await createTestServer([
@@ -522,6 +595,78 @@ test('publishInstructions(tag, type, data) - js', async () => {
         'a12das3d.json',
         '12da321fd.json',
     ]);
+
+    expect(result).toMatchSnapshot();
+
+    await closeServer(server);
+});
+
+test('publishInstructions(tag, type, data) - js - options', async () => {
+    expect.assertions(1);
+    const { server, port } = await createTestServer([
+        {
+            verb: 'post',
+            path: '/publish-instructions',
+            cb: (req, res) => res.send(req.query),
+        },
+    ]);
+
+    const client = new Client({
+        buildServerUri: `http://127.0.0.1:${port}`,
+        minify: true,
+        sourceMaps: true,
+    });
+    const result = await client.publishInstructions('a', 'js', ['b']);
+
+    expect(result).toMatchSnapshot();
+
+    await closeServer(server);
+});
+
+test('publishInstructions(tag, type, data) - js - query params', async () => {
+    expect.assertions(1);
+    const { server, port } = await createTestServer([
+        {
+            verb: 'post',
+            path: '/publish-instructions',
+            cb: (req, res) => res.send(req.query),
+        },
+    ]);
+
+    const client = new Client({ buildServerUri: `http://127.0.0.1:${port}` });
+    const result = await Promise.all([
+        client.publishInstructions('a', 'js', ['b'], { minify: true }),
+        client.publishInstructions('a', 'js', ['b'], { minify: false }),
+        client.publishInstructions('a', 'js', ['b'], { sourceMaps: true }),
+        client.publishInstructions('a', 'js', ['b'], { sourceMaps: false }),
+        client.publishInstructions('a', 'js', ['b'], { minify: null }),
+        client.publishInstructions('a', 'js', ['b'], { sourceMaps: null }),
+    ]);
+
+    expect(result).toMatchSnapshot();
+
+    await closeServer(server);
+});
+
+test('publishInstructions(tag, type, data) - js - query params overrides options', async () => {
+    expect.assertions(1);
+    const { server, port } = await createTestServer([
+        {
+            verb: 'post',
+            path: '/publish-instructions',
+            cb: (req, res) => res.send(req.query),
+        },
+    ]);
+
+    const client = new Client({
+        buildServerUri: `http://127.0.0.1:${port}`,
+        minify: true,
+        sourceMaps: true,
+    });
+    const result = await client.publishInstructions('a', 'js', ['b'], {
+        minify: false,
+        sourceMaps: false,
+    });
 
     expect(result).toMatchSnapshot();
 

--- a/test/unit/main.test.js
+++ b/test/unit/main.test.js
@@ -2,7 +2,7 @@
 
 let Client = require('../../');
 
-const buildServerUri = 'http://server';
+const buildServerUri = 'http://server.com:3000';
 
 function createRequestMock(error, response, body) {
     const { PassThrough } = require('stream');
@@ -80,7 +80,7 @@ test('new Client(options) 2', () => {
 test('new Client(options) 3', () => {
     const subject = new Client({ buildServerUri });
 
-    expect(subject.buildServerUri).toEqual('http://server');
+    expect(subject.buildServerUri).toEqual('http://server.com:3000');
 });
 
 test('transform(transform, options)', () => {

--- a/test/unit/utils.test.js
+++ b/test/unit/utils.test.js
@@ -1,0 +1,58 @@
+'use strict';
+
+const { buildURL } = require('../../lib/utils');
+
+test('buildURL with no params', () => {
+    const result = buildURL('http://server.com');
+    expect(result).toEqual('http://server.com/');
+});
+
+test('buildURL with 1 param', () => {
+    const result = buildURL('http://server.com', { prop: 'value' });
+    expect(result).toEqual('http://server.com/?prop=value');
+});
+
+test('buildURL with multiple params', () => {
+    const result = buildURL('http://server.com', {
+        prop1: 'value',
+        prop2: 'value',
+        prop3: 'value',
+    });
+    expect(result).toEqual(
+        'http://server.com/?prop1=value&prop2=value&prop3=value'
+    );
+});
+
+test('buildURL with param with undefined value', () => {
+    const result = buildURL('http://server.com', { prop: undefined });
+    expect(result).toEqual('http://server.com/');
+});
+
+test('buildURL with param with null value', () => {
+    const result = buildURL('http://server.com', { prop: null });
+    expect(result).toEqual('http://server.com/');
+});
+
+test('buildURL with object param serialized', () => {
+    const result = buildURL('http://server.com', { prop: { key: 'value' } });
+    expect(result).toEqual(
+        'http://server.com/?prop=%7B%22key%22%3A%22value%22%7D'
+    );
+});
+
+test('buildURL with array param serialized', () => {
+    const result = buildURL('http://server.com', { prop: ['one', 'two'] });
+    expect(result).toEqual(
+        'http://server.com/?prop=%5B%22one%22%2C%22two%22%5D'
+    );
+});
+
+test('buildURL with number param', () => {
+    const result = buildURL('http://server.com', { prop: 1 });
+    expect(result).toEqual('http://server.com/?prop=1');
+});
+
+test('buildURL with boolean param', () => {
+    const result = buildURL('http://server.com', { prop: true });
+    expect(result).toEqual('http://server.com/?prop=true');
+});


### PR DESCRIPTION
## JIRA Issue
[COREWEB-26](https://jira.finn.no/browse/COREWEB-26)

## Status
**IN DEVELOPMENT**

## Description
Allows passing of `minify` and `sourceMaps` options to the client which in turn sends these on to the build server as query params. The server already supports these as query params.

Note: sourceMaps functionality in @asset-pipe is still experimental
currently due to non determinism.

## Todos
- [x] Tests
- [x] Documentation

## Deploy Notes
Backward compatible feature. Should be no issue to roll this out to existing servers without any code changes.

## Related PRs
* None