### PR TITLE
Add sync and better input checking

### DIFF
--- a/README.md
+++ b/README.md
@@ -278,6 +278,18 @@ Creates an asset bundle on the
 * `feeds` - Array - List of asset-feed filenames.
 * `type` - string - Either 'js' or 'css'
 
+### sync()
+
+Fetches centralised configuration information from the asset server.
+This should be called after creating a new client instance and before any calls to `.bundleURL()` or `.bundlingComplete()`
+
+**Example**
+
+```js
+const client = new Client(options);
+await client.sync();
+```
+
 ### publishAssets(tag, entrypoints, options)
 
 Publishes assets to the asset server for use in optimisitic bundling. Bundles
@@ -363,6 +375,8 @@ Calculation is done by sha256 hashing together the given `hashes` and dropping t
 
 As such, this method does not perform any requests to the server and therefore cannot guarantee that the bundle exists on the server.
 
+**Note:** You should call `await client.sync();` one time after creating the client instance, before calling `bundleURL` to ensure the client has update information about the public location of bundle files.
+
 * `hashes` - `string[]` - array of asset feed content hashes as returned by `client.publishAssets`
 * `options` - `object`
   * `options.prefix` - `string` url prefix to use when building bundle url. Defaults to `${client.buildServerUri}/bundle/` which is the location on the asset server that a bundle can be located. Overwrite this if you use a CDN and need to point to that.
@@ -387,6 +401,8 @@ const url = await client.bundleURL([id1, id2]);
 ### bundlingComplete(feedhashes, options)
 
 Calculates whether a bundling for the given `feedHashes` has been completed. The rules for this method are as follows:
+
+**Note:** You should call `await client.sync();` one time after creating the client instance, before calling `bundleURL` to ensure the client has update information about the public location of bundle files.
 
 * If `feedHashes` is an empty array, this method resolves to `true` as no bundle needs to be built.
 * Otherwise, if `feedHashes` is not an empty array then a bundle url will be computed and a request made to check if the file exists on the server.

--- a/lib/main.js
+++ b/lib/main.js
@@ -286,6 +286,9 @@ module.exports = class Client {
 
         const type = this.determineType(entrypoints);
         const writer = this.writer(type, entrypoints, options);
+
+        const data = await getStream(writer.bundle());
+
         const { response: { statusCode }, body } = await post({
             url: buildURL(
                 url.resolve(this.buildServerUri, `${endpoints.PUBLISH_ASSETS}`),
@@ -294,7 +297,7 @@ module.exports = class Client {
             body: JSON.stringify({
                 tag,
                 type,
-                data: await getStream(writer.bundle()),
+                data,
             }),
             serverId: this.serverId,
         });
@@ -302,7 +305,7 @@ module.exports = class Client {
         const { message } = body;
 
         if (statusCode === 200) {
-            return Promise.resolve(body);
+            return body;
         }
 
         if (statusCode === 400) {

--- a/lib/main.js
+++ b/lib/main.js
@@ -85,6 +85,8 @@ module.exports = class Client {
             `Expected "buildServerUri" to be a uri, got ${buildServerUri}`
         );
         this.buildServerUri = buildServerUri;
+        this.publicFeedUrl = null;
+        this.publicBundleUrl = null;
         this.serverId = serverId;
 
         this.transforms = [];
@@ -373,6 +375,23 @@ module.exports = class Client {
         );
     }
 
+    async sync() {
+        if (!this.publicFeedUrl || !this.publicBundleUrl) {
+            const { body } = await get(
+                url.resolve(this.buildServerUri, '/sync/')
+            );
+            try {
+                const parsedBody = JSON.parse(body);
+                this.publicFeedUrl = parsedBody.publicFeedUrl;
+                this.publicBundleUrl = parsedBody.publicBundleUrl;
+            } catch (err) {
+                throw new Boom(
+                    'Unable to perform client/server sync as server returned an unparsable response'
+                );
+            }
+        }
+    }
+
     bundleHash(feedHashes) {
         return hashArray(feedHashes);
     }
@@ -381,20 +400,41 @@ module.exports = class Client {
         return `${hash}.${type}`;
     }
 
-    async bundleURL(feedHashes, options = {}) {
+    bundleURL(feedHashes, options = {}) {
+        assert(
+            Array.isArray(feedHashes),
+            `Expected argument 'feedHashes' to be an array when calling 'bundleURL(feedHashes)'. Instead 'feedHashes' was ${typeof feedHashes}`
+        );
+        assert(
+            feedHashes.every(source => typeof source === 'string'),
+            `Expected all entries in array 'feedHashes' to be strings when calling 'bundleURL(feedHashes)'. Instead 'feedHashes' was ${feedHashes}`
+        );
+
         if (feedHashes.length === 0) return null;
+
         const { type, prefix } = {
-            prefix: url.resolve(this.buildServerUri, '/bundle/'),
+            prefix:
+                this.publicBundleUrl ||
+                url.resolve(this.buildServerUri, '/bundle/'),
             type: 'js',
             ...options,
         };
-        const hash = await this.bundleHash(feedHashes);
+        const hash = this.bundleHash(feedHashes);
         const filename = this.bundleFilename(hash, type);
         return url.resolve(prefix, filename);
     }
 
     async bundlingComplete(feedHashes, options = {}) {
-        const uri = await this.bundleURL(feedHashes, options);
+        assert(
+            Array.isArray(feedHashes),
+            `Expected argument 'feedHashes' to be an array when calling 'bundlingComplete'. Instead 'feedHashes' was ${typeof feedHashes}`
+        );
+        assert(
+            feedHashes.every(source => typeof source === 'string'),
+            `Expected all entries in array 'feedHashes' to be strings when calling 'bundlingComplete'. Instead 'feedHashes' was ${feedHashes}`
+        );
+
+        const uri = this.bundleURL(feedHashes, options);
         if (!uri) return true;
         const { response } = await get(uri);
         return response.statusCode >= 200 && response.statusCode < 300;

--- a/lib/main.js
+++ b/lib/main.js
@@ -427,11 +427,11 @@ module.exports = class Client {
     async bundlingComplete(feedHashes, options = {}) {
         assert(
             Array.isArray(feedHashes),
-            `Expected argument 'feedHashes' to be an array when calling 'bundlingComplete'. Instead 'feedHashes' was ${typeof feedHashes}`
+            `Expected argument 'feedHashes' to be an array when calling 'bundlingComplete(feedHashes)'. Instead 'feedHashes' was ${typeof feedHashes}`
         );
         assert(
             feedHashes.every(source => typeof source === 'string'),
-            `Expected all entries in array 'feedHashes' to be strings when calling 'bundlingComplete'. Instead 'feedHashes' was ${feedHashes}`
+            `Expected all entries in array 'feedHashes' to be strings when calling 'bundlingComplete(feedHashes)'. Instead 'feedHashes' was ${feedHashes}`
         );
 
         const uri = this.bundleURL(feedHashes, options);

--- a/lib/main.js
+++ b/lib/main.js
@@ -385,9 +385,10 @@ module.exports = class Client {
                 this.publicFeedUrl = parsedBody.publicFeedUrl;
                 this.publicBundleUrl = parsedBody.publicBundleUrl;
             } catch (err) {
-                throw new Boom(
-                    'Unable to perform client/server sync as server returned an unparsable response'
-                );
+                throw Boom.boomify(err, {
+                    message:
+                        'Unable to perform client/server sync as server returned an unparsable response',
+                });
             }
         }
     }

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,9 +5,9 @@
   "requires": true,
   "dependencies": {
     "@asset-pipe/common": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@asset-pipe/common/-/common-2.0.0.tgz",
-      "integrity": "sha512-9ajcAlzfusBodEwRPhmvmKvh7okWGnybr8Yek9j6FW2Ek7TVKABpBM1KYSrXCYfDJzolN11+9Hxpe8o3YViBvw==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@asset-pipe/common/-/common-3.0.0.tgz",
+      "integrity": "sha512-G0thyyIF0oJWw1TxUukY+gsIj5xC25wmTcrUww3347lH6OlXlvTM8gZk36YOgf8ekEyvetu0pe7D2DBvx7KRXw==",
       "requires": {
         "readable-stream": "2.3.3"
       },

--- a/test/unit/main.test.js
+++ b/test/unit/main.test.js
@@ -345,7 +345,7 @@ test('publishInstructions(tag, type, data) - invalid type', async () => {
 test('bundleURL(hashes, options) - js', async () => {
     expect.assertions(1);
     const client = new Client({ buildServerUri });
-    const url = await client.bundleURL(['a', 'b']);
+    const url = client.bundleURL(['a', 'b']);
     expect(url).toBe(
         'http://server.com:3000/bundle/fb8e20fc2e4c3f248c60c39bd652f3c1347298bb977b8b4d5903b85055620603.js'
     );
@@ -354,7 +354,7 @@ test('bundleURL(hashes, options) - js', async () => {
 test('bundleURL(hashes, options) - css', async () => {
     expect.assertions(1);
     const client = new Client({ buildServerUri });
-    const url = await client.bundleURL(['a', 'b'], { type: 'css' });
+    const url = client.bundleURL(['a', 'b'], { type: 'css' });
     expect(url).toBe(
         'http://server.com:3000/bundle/fb8e20fc2e4c3f248c60c39bd652f3c1347298bb977b8b4d5903b85055620603.css'
     );
@@ -363,7 +363,7 @@ test('bundleURL(hashes, options) - css', async () => {
 test('bundleURL(hashes, options) - js with prefix', async () => {
     expect.assertions(1);
     const client = new Client({ buildServerUri });
-    const url = await client.bundleURL(['a', 'b'], { prefix: 'http://server' });
+    const url = client.bundleURL(['a', 'b'], { prefix: 'http://server' });
     expect(url).toBe(
         'http://server/fb8e20fc2e4c3f248c60c39bd652f3c1347298bb977b8b4d5903b85055620603.js'
     );
@@ -372,7 +372,7 @@ test('bundleURL(hashes, options) - js with prefix', async () => {
 test('bundleURL(hashes, options) - empty array returns null', async () => {
     expect.assertions(1);
     const client = new Client({ buildServerUri });
-    const url = await client.bundleURL([]);
+    const url = client.bundleURL([]);
     expect(url).toBe(null);
 });
 


### PR DESCRIPTION
## Status
**IN DEVELOPMENT**

## Description
Adds a sync method to client which can be used to retrieve information from an asset server. The main usecase for this currently is to get a reference to the location of published assets so that an accurate url can be built for the `bundleURL` and `bundlingComplete` methods.

## Todos
- [x] Tests
- [ ] Documentation

## Deploy Notes
Anything using the `bundleURL` or `bundlingComplete` methods of the asset client should take the following steps:
1. update asset client to the latest version
2. call the asset clients .sync() method 1x somewhere before any calls to `bundleURL` or `bundlingComplete`

## Related PRs
* None